### PR TITLE
Change to cjs for better compatibility with `build-and-tag-action`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import core from '@actions/core';
+const core = require('@actions/core');
 
 async function run(){
   try {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,8 @@
   "version": "1.0.0",
   "description": "An extremely simple JavaScript action for triggering webhooks. Useful for triggering deploys on Cloudflare Pages, Netlify, etc., and other situations where you only need to send a simple request to a webhook URL.",
   "main": "dist/index.js",
-  "type": "module",
   "scripts": {
-    "build": "ncc build index.js --license licenses.txt"
+    "build": "ncc build index.js --minify --no-cache --license licenses.txt"
   },
   "author": "1ockwood",
   "license": "MIT",


### PR DESCRIPTION
The `build-and-tag-action` doesn't copy the `package.json` file which is required to specify `type: module`, so switching to cjs for better compatibility. 